### PR TITLE
feat: added the functionality to get totals

### DIFF
--- a/js/zotero.js
+++ b/js/zotero.js
@@ -711,7 +711,7 @@ const selectRefTab = ( tab) => {
  * 
  * @param {(...args:any[]) => void} callback 
  */
-async function fetchTotal(callback){
+async function ZoteroFetchTotal(callback){
 
     const collections = [
         {
@@ -726,14 +726,13 @@ async function fetchTotal(callback){
 
     for (const { collectionId, type } of collections){
         const data = await fetchCollection(ZETORO_ID, collectionId)
-        const event = new CustomEvent(ZOTERO_TOTAL_EVENT_NAME, {
-            detail: {
-                type,
-                total: data.meta.numItems,
-                data
-            }
-        })
+        const detail = {
+            type,
+            total: data.meta.numItems,
+            data
+        }
+        const event = new CustomEvent(ZOTERO_TOTAL_EVENT_NAME, { detail })
         document.dispatchEvent(event)
-        callback && callback(event)
+        callback && callback(detail)
     }
 }

--- a/js/zotero.js
+++ b/js/zotero.js
@@ -711,7 +711,7 @@ const selectRefTab = ( tab) => {
  * 
  * @param {(...args:any[]) => void} callback 
  */
-async function ZoteroFetchTotal(callback){
+async function zoteroFetchTotal(callback){
 
     const collections = [
         {

--- a/js/zotero.js
+++ b/js/zotero.js
@@ -13,7 +13,7 @@ const ZETORO_COLLECTION = 'XT9EWQJJ'
 const ZOTERO_COMMUNITY_COLLECTION = 'PYKR9D36'
 const ZETORO_LIMIT = 2000
 const ZOTERO_ITEM_TYPES = ["journalArticle", "preprint", "presentation", "thesis", "conferencePaper"]
-
+const ZOTERO_TOTAL_EVENT_NAME = "bbp:zotero:total"
 /**
  * 
  * @param {string} input
@@ -156,6 +156,33 @@ const disableLoading = () => {
  * @property {string} name
  * @property {ZetoroResp[]} items 
  */
+
+/**
+ * @typedef {Object} Meta
+ * @property {number} numCollections
+ * @property {number} numItems
+ * 
+ * @typedef {Object} ZetoroCollection
+ * @property {Meta} meta
+ * @property {number} version
+ * @property {ZetoroLibrary} library
+ * @property {string} key
+ */
+
+/**
+ * @description Fetches collection info. 
+ * @param {string} groupId 
+ * @param {string} collectionId 
+ * @returns {Promise<ZetoroCollection>}
+ */
+async function fetchCollection(groupId, collectionId){
+    const url = new URL(`https://api.zotero.org/groups/${groupId}/collections/${collectionId}`)
+
+    // TODO not sure if this is necessary
+    url.searchParams.set("itemType", ZOTERO_ITEM_TYPES.join(" || "))
+    const resp = await fetch(url)
+    return await resp.json()
+}
 
 /**
  * 
@@ -677,4 +704,36 @@ const selectRefTab = ( tab) => {
 
     document.getElementById(tab).style.display = 'block'
     document.getElementById(tab+'-button').className += ' active'
+}
+
+
+/**
+ * 
+ * @param {(...args:any[]) => void} callback 
+ */
+async function fetchTotal(callback){
+
+    const collections = [
+        {
+            type: "main",
+            collectionId: ZETORO_COLLECTION
+        },
+        {
+            type: "community",
+            collectionId: ZOTERO_COMMUNITY_COLLECTION
+        }
+    ]
+
+    for (const { collectionId, type } of collections){
+        const data = await fetchCollection(ZETORO_ID, collectionId)
+        const event = new CustomEvent(ZOTERO_TOTAL_EVENT_NAME, {
+            detail: {
+                type,
+                total: data.meta.numItems,
+                data
+            }
+        })
+        document.dispatchEvent(event)
+        callback && callback(event)
+    }
 }


### PR DESCRIPTION
fixes #275 

usage:

either

```js

// add after zotero.js is loaded

console.log(ZOTERO_TOTAL_EVENT_NAME) // bbp:zotero:total
document.addEventListener(ZOTERO_TOTAL_EVENT_NAME, ev => {
    console.log(ev.detail.type) // 'main' || 'community'
    console.log(ev.detail.total) // total entries
})
zoteroFetchTotal()
```

OR

```js
zoteroFetchTotal(detail => {
    console.log(detail.type) // 'main' || 'community'
    console.log(detail.total) // total entries
})
```

@SusanneWenzel can you the numbers are right? At the moment:

- main collection (collection id `XT9EWQJJ`) is `145` entries

- community collection (collection id `PYKR9D36`) is `25` entries